### PR TITLE
Enable custom overflow ignore setting.

### DIFF
--- a/FreqMeasure.h
+++ b/FreqMeasure.h
@@ -5,11 +5,12 @@
 
 class FreqMeasureClass {
 public:
-	static void begin(void);
-	static uint8_t available(void);
-	static uint32_t read(void);
-	static float countToFrequency(uint32_t count);
-	static void end(void);
+  static void begin(void);
+  static uint8_t available(void);
+  static uint32_t read(void);
+  static float countToFrequency(uint32_t count);
+  static void end(void);
+  static void setOverflowIgnoreTicks(uint16_t ticks);
 };
 
 extern FreqMeasureClass FreqMeasure;


### PR DESCRIPTION
I noticed the default values here caused false readings that were off by ~2^16 ticks on my ATmega328P-AU (5V/16Mhz). Tweaking this value to `0xC000` instead of `0xFF00` reduced them significantly for me. So I figured more people might need to tweak this setting.
I've preserved your default values and added a setting for it.